### PR TITLE
Fixed finding public queries

### DIFF
--- a/app/views/settings/_enhanced_my_page.html.erb
+++ b/app/views/settings/_enhanced_my_page.html.erb
@@ -4,7 +4,7 @@ default_my_page_blocks_left=@settings['default_my_page_blocks_left'] || defaults
 default_my_page_blocks_right=@settings['default_my_page_blocks_right'] || defaults['default_my_page_blocks_right']
 default_my_page_blocks_top=@settings['default_my_page_blocks_top'] || defaults['default_my_page_blocks_top']
 
-queries=Query.find(:all, :conditions => ["project_id IS NULL AND is_public=?", true])
+queries=Query.find(:all).select(&:is_public?)
 if queries.nil?
 	q=[]
 else

--- a/lib/enhanced_my_page/my_controller_patch.rb
+++ b/lib/enhanced_my_page/my_controller_patch.rb
@@ -32,7 +32,7 @@ module EnhancedMyPage
       def page_layout_with_enhanced_my_page
         page_layout_without_enhanced_my_page  
         @blocks = @user.pref[:my_page_layout] || @enhanced_default_layout
-        queries_for_my_page=Query.find(:all, :conditions => ["project_id IS NULL AND is_public=?", true])
+        queries_for_my_page=Query.find(:all).select(&:is_public?)
         queries_for_my_page.each{|e|
           @block_options << [e.name.to_s, "query#{e.id}"]
         }


### PR DESCRIPTION
В redmine-2.4 в таблице queries больше нет столбца is_public, теперь необходимо по-другому делать запрос. Я немного переписал запрос, теперь плагин снова работает.
